### PR TITLE
chore: add a volatile keyword to keep a error check in OSInitHook

### DIFF
--- a/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
+++ b/Ports/ARM-Cortex-M/ARMv7-M/os_cpu_c.c
@@ -114,7 +114,7 @@ void  OSIdleTaskHook (void)
 void  OSInitHook (void)
 {
 #if (OS_CPU_ARM_FP_EN > 0u)
-    CPU_INT32U   reg_val;
+    volatile CPU_INT32U   reg_val;
 #endif
                                                                 /* 8-byte align the ISR stack.                          */
     OS_CPU_ExceptStkBase = (CPU_STK *)(OSCfg_ISRStkBasePtr + OSCfg_ISRStkSize);


### PR DESCRIPTION
OSInitHook has a error check to make sure the M4F FPU is in correct mode. As such the FPU in STM32G4 M4F is in correct state on reset and this check will always pass. However making sure the error check stays active in the final binary could help catch issues in some other platforms