### PR TITLE
feat: uCOS3 port for Sifive E2x RISC-V

### DIFF
--- a/Ports/RISC-V/RV32/GCC/os_cpu_a.S
+++ b/Ports/RISC-V/RV32/GCC/os_cpu_a.S
@@ -35,7 +35,6 @@
     .extern  OSPrioHighRdy
     .extern  OSTCBCurPtr
     .extern  OSTCBHighRdyPtr
-    .extern  OSIntExit
     .extern  OSTaskSwHook
 
 
@@ -43,17 +42,18 @@
     .global  OSCtxSw
     .global  OSIntCtxSw
     .global  Software_IRQHandler
+    .global  ucos_intr_exception_handler
 
 
 #********************************************************************************************************
 #                                               EQUATES
 #********************************************************************************************************
 
-    .equ  RISCV_MSTATUS_MIE,         0x08
+    .equ  RISCV_MSTATUS_MIE,          0x08
 
-    .equ  RISCV_MIE_MSIE,            0x08            # M Soft Interrupt bit
+    .equ  ARCH_CPU_MCAUSE_INTR_MASK,  0x80000000
 
-    .equ  RISCV_PRCI_BASE_ADDR,      0x44000000
+    .equ  ARCH_CPU_MCAUSE_CAUSE_MASK, 0x000003FF
 
 
 #********************************************************************************************************
@@ -78,27 +78,38 @@
 
 OSStartHighRdy:
 # Disable interrupts
+    # load immediately "RISCV_MSTATUS_MIE" into t0 register
     li     t0, RISCV_MSTATUS_MIE
+    # mstatus = mstatus & ~t0
     csrrc  zero, mstatus, t0
 
 # Execute OS task switch hook.
+    # jump to OSTaskSwHook function(address) and store the next instruction
+    # into link register
+    # this function will get called each time when the context switch happens
     jal    OSTaskSwHook
 
 # OSRunning = TRUE;
     li     t0, 0x01
+    # load address of OSRunning into t1 register
     la     t1, OSRunning
+    # store byte value of t0 into memory address pointed by t1 with 0 offset
     sb     t0, 0(t1)
 
 # SWITCH TO HIGHEST PRIORITY TASK
     la     t0, OSTCBHighRdyPtr
+    # load word from address stored in [t0 + 0(offset)] to t1
     lw     t1, 0(t0)
+    # load word from address stored in [t1+ 0(offset)] into sp
     lw     sp, 0(t1)
 
 # Retrieve the location where to jump
     lw     t0, 31 * 4(sp)
+    # value stored in t0 is stored into mepc
     csrw   mepc, t0
 
 # Restore x1 to x31 registers
+    # load word from memory addres [(0 * 4) + sp] into ra register
     lw     ra,   0 * 4(sp)
     lw     t0,   4 * 4(sp)
     lw     t1,   5 * 4(sp)
@@ -129,6 +140,7 @@ OSStartHighRdy:
     lw     t6,  30 * 4(sp)
 
 # Compensate for the stack pointer
+    # sp = sp + 32 * 4
     addi   sp, sp, 32 * 4
 
 # Use register t6 to jump to HIGHEST priority
@@ -147,66 +159,116 @@ OSStartHighRdy:
 #                   PERFORM A CONTEXT SWITCH (From interrupt level) - OSIntCtxSw()
 #
 # Note(s) : 1) OSCtxSw() is called when OS wants to perform a task context switch.  This function
-#              triggers a synchronous software interrupt by writing into the MSIP register
+#              triggers a ecall.
 #
 #           2) OSIntCtxSw() is called by OSIntExit() when it determines a context switch is needed as
-#              the result of an interrupt.  This function triggers a synchronous software interrupt by
-#              writing into the MSIP register
+#              the result of an interrupt.  This function just return back as the context switch after interrupt
+#              is executed just before exiting the interrupt handler.
 #********************************************************************************************************
+OSIntCtxSw:
+    ret
 
 OSCtxSw:
-OSIntCtxSw:
-# MIE_MSIE -- enable software interrupt bit
-    li     t0, RISCV_MIE_MSIE
-    csrrs  zero, mie, t0
-
-# This will trigger a synchronous software interrupt; PRCI->MSIP[0] = 0x01;
-    li     t0, RISCV_PRCI_BASE_ADDR
-    li     t1, 0x1
-    sw     t1, 0x0(t0)
+    ecall
     ret
+
+# Exception handler should be 256 bytes aligned
+.align 8
+ucos_intr_exception_handler:
+    # save regs to current sp
+    addi sp, sp, -4*32
+    # store contents of register ra into memory [(0 * 4) + sp]
+    sw     ra,   0 * 4(sp)
+    sw     t0,   4 * 4(sp)
+    sw     t1,   5 * 4(sp)
+    sw     t2,   6 * 4(sp)
+    sw     s0,   7 * 4(sp)
+    sw     s1,   8 * 4(sp)
+    sw     a0,   9 * 4(sp)
+    sw     a1,  10 * 4(sp)
+    sw     a2,  11 * 4(sp)
+    sw     a3,  12 * 4(sp)
+    sw     a4,  13 * 4(sp)
+    sw     a5,  14 * 4(sp)
+    sw     a6,  15 * 4(sp)
+    sw     a7,  16 * 4(sp)
+    sw     s2,  17 * 4(sp)
+    sw     s3,  18 * 4(sp)
+    sw     s4,  19 * 4(sp)
+    sw     s5,  20 * 4(sp)
+    sw     s6,  21 * 4(sp)
+    sw     s7,  22 * 4(sp)
+    sw     s8,  23 * 4(sp)
+    sw     s9,  24 * 4(sp)
+    sw     s10, 25 * 4(sp)
+    sw     s11, 26 * 4(sp)
+    sw     t3,  27 * 4(sp)
+    sw     t4,  28 * 4(sp)
+    sw     t5,  29 * 4(sp)
+    sw     t6,  30 * 4(sp)
+
+    # If it is a ecall, do not add 4 in mepc
+    # otherwise add 4 in mepc
+    li t1, ARCH_CPU_MCAUSE_CAUSE_MASK
+    csrr  t0, mcause
+    # t3 = t1 & t0
+    and t3, t1, t0
+    li t1, 11
+    csrr   t0,  mepc
+    # If t1 != t3 jump to DONTADD:
+    bne t1, t3, DONTADD
+    addi   t0,  t0, 4
+   
+DONTADD: # for interrupt do not add 4 in mepc
+    sw     t0,  31*4(sp)
+    # load address of OSTCBCurPtr into t0 register
+    la     t0, OSTCBCurPtr
+    # load word from register [t0 + 0] address into t1
+    lw     t1, 0(t0)
+    # store value stored in sp to [t1 + 0] address
+    sw     sp, 0(t1)
+
+    li t1, ARCH_CPU_MCAUSE_INTR_MASK
+    csrr  t0, mcause
+    and t2, t1, t0
+    bne t1, t2, run_exception_handler
+    # it is a interrupt
+    j run_interrupt_exception_handler
+
+run_exception_handler:
+    li t1, ARCH_CPU_MCAUSE_CAUSE_MASK
+    csrr  t0, mcause
+    and t3, t1, t0
+    li t1, 11
+    bne t1, t3, run_interrupt_exception_handler
+    # it is a ecall
+    j run_ecall_handler
+
+run_interrupt_exception_handler:
+    jal osa_intr_master_isr 
+
+run_ecall_handler:
+    j Software_IRQHandler
+
+
 
 
 #********************************************************************************************************
 #                                   void Software_IRQHandler (void)
 #
-# Note(s) : 1) This function is defined with weak linking in 'riscv_hal_stubs.c' so that it can be
-#              overridden by the kernel port with same prototype.
+#           1) Pseudo-code is:
+#              a) Call OSTaskSwHook();
+#              b) Get current high priority, OSPrioCur = OSPrioHighRdy;
+#              c) Get current ready thread TCB, OSTCBCurPtr = OSTCBHighRdyPtr;
+#              d) Get new process SP from TCB, SP = OSTCBHighRdyPtr->StkPtr;
+#              e) Retrieve the address at which exception happened.
+#              f) Restore x1-x31 from new process stack; x0 is always zero.
+#              g) set MPIE = 1 to enable interrupt before returning.
+#              h) Perform exception return which will restore remaining context.
 #
-#           2) Pseudo-code is:
-#              a) Disable global interrupts.
-#              b) Clear soft interrupt for hart0.
-#              c) Save the process SP in its TCB, OSTCBCurPtr->StkPtr = SP;
-#              d) Call OSTaskSwHook();
-#              e) Get current high priority, OSPrioCur = OSPrioHighRdy;
-#              f) Get current ready thread TCB, OSTCBCurPtr = OSTCBHighRdyPtr;
-#              g) Get new process SP from TCB, SP = OSTCBHighRdyPtr->StkPtr;
-#              h) Retrieve the address at which exception happened
-#              i) Restore x1-x31 from new process stack; x0 is always zero.
-#              j) Perform exception return which will restore remaining context.
-#
-#           3) On entry into Software_IRQHandler:
-#              a) The initial register context save is being done by 'entry.S'
-#              b) Stack pointer was passed by 'entry.s' in register a2.
-#              c) OSTCBCurPtr      points to the OS_TCB of the task to suspend
-#                 OSTCBHighRdyPtr  points to the OS_TCB of the task to resume
 #********************************************************************************************************
 
 Software_IRQHandler:
-# Disable interrupts globally and prevent interruption during context switch
-    li     t0, RISCV_MSTATUS_MIE
-    csrrc  zero, mstatus, t0
-
-# Clear soft interrupt for hart0, PRCI->MSIP[0] = 0x00;
-    li     t0, RISCV_PRCI_BASE_ADDR
-    sw     zero, 0x0(t0)
-
-# Stack pointer was passed by 'entry.s' in register a2.
-# OSTCBCurPtr->StkPtr = SP;
-    la     t0, OSTCBCurPtr
-    lw     t1, 0(t0)
-    sw     a2, 0(t1)
-
 # Execute OS task switch hook.
     jal    OSTaskSwHook
 
@@ -259,11 +321,15 @@ Software_IRQHandler:
     lw     t5,  29 * 4(sp)
     lw     t6,  30 * 4(sp)
 
+# Compensate for the stack pointer
     addi   sp, sp, 4 * 32
 
 # Exception return will restore remaining context
+    # set MPIE = 1
+    # interrupts will be enabled from here onwards
+    li t0, 0x80
+    csrrs zero, mstatus, t0   
     mret
-
 
 #********************************************************************************************************
 #                                             MODULE END

--- a/Ports/RISC-V/RV32/GCC/os_cpu_c.c
+++ b/Ports/RISC-V/RV32/GCC/os_cpu_c.c
@@ -443,36 +443,6 @@ void  OSTimeTickHook (void)
 #endif
 }
 
-
-/*
-*********************************************************************************************************
-*                                          SYS TICK HANDLER
-*
-* Description: Handle the system tick (SysTick) interrupt, which is used to generate the uC/OS-III tick
-*              interrupt.
-*
-* Arguments  : None.
-*
-* Note(s)    : This function is defined with weak linking in 'riscv_hal_stubs.c' so that it can be
-*              overridden by the kernel port with same prototype
-*********************************************************************************************************
-*/
-
-void  SysTick_Handler (void)
-{
-    CPU_SR_ALLOC();                            /* Allocate storage for CPU status register             */
-
-
-    CPU_CRITICAL_ENTER();
-    OSIntEnter();                              /* Tell uC/OS-III that we are starting an ISR           */
-    CPU_CRITICAL_EXIT();
-
-    OSTimeTick();                              /* Call uC/OS-III's OSTimeTick()                        */
-
-    OSIntExit();                               /* Tell uC/OS-III that we are leaving the ISR           */
-}
-
-
 /*
 *********************************************************************************************************
 *                                   EXTERNAL C LANGUAGE LINKAGE END


### PR DESCRIPTION
## Description
uCOS3 port for Sifive E2x RISC-V

This commit contains changes for enabling interrupt(including timer interrupt) in uC-OS RISC V port.

- Saving and restoring of registers during context switch (task to task, interrupt to task, task to interrupt)
- Removed systick handler as we are directly calling OSTimeTick() from timer ISR.
- Added comments in os_cpu_a.S file for better understanding of assembly line instruction.

## Jira Links

## Type of change
* New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
This change has been tested with osa_task_switch test case. and it supposed be to switch task to task,task to interrupt 
and interrupt to task, during any transition it should save the current context and load the next context. 

## Checklist:

- [x] Comments updated and spell checked
- [x] Corresponding documentation changes included
- [x] Review commits squashed
- [x] Final commit retested





